### PR TITLE
profiles/features/prefix/standalone: mask getentropy

### DIFF
--- a/profiles/features/prefix/standalone/package.use.mask
+++ b/profiles/features/prefix/standalone/package.use.mask
@@ -15,3 +15,7 @@ net-misc/openssh pam
 # Benda Xu <heroxbd@gentoo.org> (2019-01-26)
 # native-extensions requires >=linux=4.6 for __NR_copy_file_range
 sys-apps/portage native-extensions
+
+# Bart Oldeman <bart.oldeman@calculquebec.ca> (2022-03-02)
+# getentropy requires >=linux=3.17 for __NR_getrandom
+dev-libs/libgcrypt getentropy


### PR DESCRIPTION
When bootstrapping on a 3.10 kernel (e.g. CentOS 7.x), libgcrypt notes the following:
```
 * Messages for package dev-libs/libgcrypt-1.10.1-r3:
 * The getentropy function requires the getrandom syscall.
 * This was introduced in Linux 3.17.
 * Your system is currently running Linux 3.10.0-1160.45.1.el7.x86_64.
 * Disable the 'getentropy' USE flag or upgrade your kernel.
 * ERROR: dev-libs/libgcrypt-1.10.1-r3::gentoo failed (pretend phase):
 *   Kernel is too old for getentropy
```
Since without getrandom it will do a runtime check it's ok to mask.